### PR TITLE
Make requirements more permissive

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,6 @@ requests>2,<3
 urllib3>1.24,<2
 websocket-client>=0.56.0,<2
 websockets>=8.0,<10
-msgpack==1.0.2
-aiohttp==3.7.4
-PyYAML==5.4.1
+msgpack>=1.0.2
+aiohttp>=3.7.4
+PyYAML>=5.4.1


### PR DESCRIPTION
aiohttp==3.7.4 conflicts with ccxt which requires [>=3.8](https://github.com/ccxt/ccxt/commit/2ce0291516fc02cf0cb6feeab8f51c832fa3e3bb)